### PR TITLE
wip - 1 edge case is missing and still need a debug

### DIFF
--- a/src/TimesRange.js
+++ b/src/TimesRange.js
@@ -84,26 +84,6 @@ export default class TimesRange extends Component {
     })
   };
 
-  // handleDayClick = day => {
-  //   this.setState(prevState => {
-  //     const { startDate, endDate } = prevState;
-  //     const endDateDate =
-  //       endDate === null
-  //         ? null
-  //         : new Date(endDate.year, endDate.month, endDate.day);
-  //     const date = new Date(day.year, day.month, day.day);
-      
-  //     /** @todo copy logic from Google */
-  //     if (startDate === null) {
-  //       return { startDate: day };
-  //     }
-  //     if (endDateDate === null) {
-  //       return { endDate: day };
-  //     }
-  //     return { startDate: day, endDate: null };
-  //   });
-  // };
-
   close = () => {
     this.setState({ open: false });
   };

--- a/src/TimesRange.js
+++ b/src/TimesRange.js
@@ -76,12 +76,19 @@ export default class TimesRange extends Component {
       else if (selectedDay < prevStartDate) {
         return { startDate: day}
       } 
-      else if (selectedDay > prevStartDate && selectedDay > prevStartDate) {
+      else if (selectedDay > prevEndDate && selectedDay > prevStartDate) {
         return { endDate: day}
       } 
       else if (selectedDay > prevEndDate){
         return { endDate: day}
       } 
+      /**
+       * @desc When a user select a time between 2 existing points 
+       * @todo Write a real logic for this one 
+       * */
+      else if(selectedDay > prevStartDate && selectedDay < prevEndDate) {
+        return { startDate: day} 
+      }
       else {
         return { startDate: null, endDate: null}
       }

--- a/src/TimesRange.js
+++ b/src/TimesRange.js
@@ -16,6 +16,7 @@ import "@material/elevation/dist/mdc.elevation.css";
 import "@material/ripple/dist/mdc.ripple.css";
 import "@material/theme/dist/mdc.theme.css";
 import "./TimesRange.css";
+import { getDate } from './utils/date'
 
 /**
  * @todo
@@ -53,26 +54,55 @@ export default class TimesRange extends Component {
       this.setState({ open: true });
     }
   };
-
   handleDayClick = day => {
     this.setState(prevState => {
       const { startDate, endDate } = prevState;
-      const endDateDate =
-        endDate === null
-          ? null
-          : new Date(endDate.year, endDate.month, endDate.day);
-      const date = new Date(day.year, day.month, day.day);
-
-      /** @todo copy logic from Google */
-      if (startDate === null) {
-        return { startDate: day };
+      if(!startDate && !endDate) {
+        return { startDate: day }
+      } 
+      else if(!endDate && +getDate(day) > +getDate(prevState.startDate)) {
+        return { endDate: day }
+      } 
+      else if(!endDate && +getDate(day) < +getDate(prevState.startDate)) {
+        return { startDate: day, endDate: prevState.startDate }
+      } 
+      else if(+getDate(day) < +getDate(prevState.startDate) && +getDate(day) < +getDate(prevState.endDate) ){
+        return {startDate: day}
       }
-      if (endDateDate === null) {
-        return { endDate: day };
+      else if (+getDate(day) < +getDate(prevState.startDate)) {
+        return { startDate: day}
+      } 
+      else if (+getDate(day) > +getDate(prevState.startDate) && +getDate(day) > +getDate(prevState.startDate)) {
+        return { endDate: day}
+      } 
+      else if (+getDate(day) > +getDate(prevState.endDate)){
+        return { endDate: day}
+      } 
+      else {
+        return { startDate: null, endDate: null}
       }
-      return { startDate: day, endDate: null };
-    });
+    })
   };
+
+  // handleDayClick = day => {
+  //   this.setState(prevState => {
+  //     const { startDate, endDate } = prevState;
+  //     const endDateDate =
+  //       endDate === null
+  //         ? null
+  //         : new Date(endDate.year, endDate.month, endDate.day);
+  //     const date = new Date(day.year, day.month, day.day);
+      
+  //     /** @todo copy logic from Google */
+  //     if (startDate === null) {
+  //       return { startDate: day };
+  //     }
+  //     if (endDateDate === null) {
+  //       return { endDate: day };
+  //     }
+  //     return { startDate: day, endDate: null };
+  //   });
+  // };
 
   close = () => {
     this.setState({ open: false });

--- a/src/TimesRange.js
+++ b/src/TimesRange.js
@@ -57,25 +57,29 @@ export default class TimesRange extends Component {
   handleDayClick = day => {
     this.setState(prevState => {
       const { startDate, endDate } = prevState;
+      const selectedDay = +getDate(day);
+      const prevStartDate = +getDate(prevState.startDate);
+      const prevEndDate = +getDate(prevState.endDate);
+
       if(!startDate && !endDate) {
         return { startDate: day }
       } 
-      else if(!endDate && +getDate(day) > +getDate(prevState.startDate)) {
+      else if(!endDate && selectedDay > prevStartDate) {
         return { endDate: day }
       } 
-      else if(!endDate && +getDate(day) < +getDate(prevState.startDate)) {
+      else if(!endDate && selectedDay < prevStartDate) {
         return { startDate: day, endDate: prevState.startDate }
       } 
-      else if(+getDate(day) < +getDate(prevState.startDate) && +getDate(day) < +getDate(prevState.endDate) ){
+      else if(selectedDay < prevStartDate && selectedDay < prevEndDate ){
         return {startDate: day}
       }
-      else if (+getDate(day) < +getDate(prevState.startDate)) {
+      else if (selectedDay < prevStartDate) {
         return { startDate: day}
       } 
-      else if (+getDate(day) > +getDate(prevState.startDate) && +getDate(day) > +getDate(prevState.startDate)) {
+      else if (selectedDay > prevStartDate && selectedDay > prevStartDate) {
         return { endDate: day}
       } 
-      else if (+getDate(day) > +getDate(prevState.endDate)){
+      else if (selectedDay > prevEndDate){
         return { endDate: day}
       } 
       else {

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,7 @@
+type DateObj = {
+    day: number,
+    month: number,
+    year: number
+}
+
+export const getDate = (date: DateObj): Date => date ? new Date(date.year, date.month, date.day) : null


### PR DESCRIPTION
1. This is a first implemantaion of the needed logic (not yet DRY)
1. This PR only deals with setting a date inside the date calendar

The PR is concerned only the range section:
![image](https://user-images.githubusercontent.com/39482108/47052584-b15ed980-d1b1-11e8-92b9-e53f8d47e7f5.png)

**and doesn't concern** with texted date section:
![image](https://user-images.githubusercontent.com/39482108/47052605-c50a4000-d1b1-11e8-9c63-e26d937f89b8.png)

the only crucial edge case I still need to debug is when:
```startDate && endDate === day```

and the user presses on a date smaller then `startDate`. 
This need to reset the dates. but currently it doesnt.

If the user presses on a bigger date it all works fine the the dates are being reset.
